### PR TITLE
Drop outdated bdist_wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,6 @@ install_requires =
 packages = find:
 include_package_data = true
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = .git,__pycache__,.venv,build,dist
 max-line-length = 119


### PR DESCRIPTION
This is not needed if you don't support Python 2 version.